### PR TITLE
More hidden tracking

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 const Timeout = time.Second
 
 func main() {
-	http.HandleFunc("/favicon.png", asset)
+	http.HandleFunc("/favicon.ico", asset)
 	http.HandleFunc("/page1", page1)
 	http.HandleFunc("/page2", page2)
 	http.HandleFunc("/", index)
@@ -22,7 +22,7 @@ func asset(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	t0 := time.Now()
-	query := r.URL.Query().Get("id")
+	query := r.Header.Get("referer")
 	log.Println("IN", query)
 	defer func() {
 		t1 := time.Now()
@@ -51,7 +51,6 @@ func page1(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(`<html>
 	<head>
 		<title>Page 1</title>
-		<link rel="icon" href="/favicon.png?id=page1"/>
 	</head>
 	<body>
 		<a href="/">Index</a> - <a href="/page1">Page 1</a> - <a href="/page2">Page 2</a>
@@ -64,7 +63,6 @@ func page2(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(`<html>
 	<head>
 		<title>Page 2</title>
-		<link rel="icon" href="/favicon.png?id=page2"/>
 	</head>
 	<body>
 		<a href="/">Index</a> - <a href="/page1">Page 1</a> - <a href="/page2">Page 2</a>
@@ -77,7 +75,6 @@ func index(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(`<html>
 	<head>
 		<title>Index</title>
-		<link rel="icon" href="/favicon.png?id=index"/>
 	</head>
 	<body>
 		<a href="/">Index</a> - <a href="/page1">Page 1</a> - <a href="/page2">Page 2</a>


### PR DESCRIPTION
First of all nice idea, like it, good job.

I just deleted id query, used referer instead. And deleted favicon.png definiton beacuse by default browsers try to load favicon.ico. Much cleaner now.

```2019/04/22 01:55:14 Serving on :8080
2019/04/22 01:55:17 IN http://localhost:8080/
2019/04/22 01:55:20 IN http://localhost:8080/
2019/04/22 01:55:23 OUT http://localhost:8080/ 6.012487509s
2019/04/22 01:55:27 OUT http://localhost:8080/ 7.021298637s
2019/04/22 01:55:30 IN http://localhost:8080/
2019/04/22 01:55:33 IN http://localhost:8080/page1
2019/04/22 01:55:37 OUT http://localhost:8080/ 7.014335487s
2019/04/22 01:55:47 OUT http://localhost:8080/page1 14.032877079s
```